### PR TITLE
Move all deps to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
     "@storybook/react": "^7.0.15",
     "@storybook/react-vite": "^7.0.15",
     "@storybook/testing-library": "^0.1.0",
+    "@svgr/core": "5.5.0",
+    "@svgr/plugin-prettier": "5.5.0",
+    "@svgr/plugin-svgo": "5.5.0",
     "@types/fs-extra": "11.0.1",
     "@types/node": "20.4.1",
     "@types/react": "18.2.14",
@@ -61,13 +64,18 @@
     "@typescript-eslint/parser": "5.55.0",
     "@vitejs/plugin-react": "3.1.0",
     "auto": "10.46.0",
+    "axios": "1.4.0",
+    "chalk": "4.1.2",
     "chromatic": "6.17.3",
     "concurrently": "8.0.1",
+    "dotenv": "16.3.1",
     "eslint": "8.36.0",
     "eslint-plugin-jest": "27.2.1",
     "eslint-plugin-storybook": "0.6.12",
+    "figma-api-exporter": "0.0.2",
     "figma-js": "1.16.0",
     "figma-transformer": "2.1.0",
+    "fs-extra": "11.1.1",
     "lint-staged": "13.2.0",
     "prettier": "2.8.4",
     "react": "18.2.0",
@@ -94,15 +102,5 @@
     "plugins": [
       "npm"
     ]
-  },
-  "dependencies": {
-    "@svgr/core": "5.5.0",
-    "@svgr/plugin-prettier": "5.5.0",
-    "@svgr/plugin-svgo": "5.5.0",
-    "axios": "1.4.0",
-    "chalk": "4.1.2",
-    "dotenv": "16.3.1",
-    "figma-api-exporter": "0.0.2",
-    "fs-extra": "11.1.1"
   }
 }

--- a/src/groups/Documents.tsx
+++ b/src/groups/Documents.tsx
@@ -12,3 +12,4 @@ export { MenuReverse } from './../icons/MenuReverse';
 export { Filter } from './../icons/Filter';
 export { DocChart } from './../icons/DocChart';
 export { DocList } from './../icons/DocList';
+export { Drag } from './../icons/Drag';

--- a/src/iconList.tsx
+++ b/src/iconList.tsx
@@ -36,7 +36,7 @@ export const iconList = [
       'Stacked',
       'Sun',
       'Moon',
-    ],
+    ]
   },
   {
     name: 'Documents',
@@ -55,7 +55,8 @@ export const iconList = [
       'Filter',
       'DocChart',
       'DocList',
-    ],
+      'Drag',
+    ]
   },
   {
     name: 'Editing',
@@ -68,15 +69,27 @@ export const iconList = [
       'ListUnordered',
       'Paragraph',
       'Markdown',
-    ],
+    ]
   },
   {
     name: 'Git',
-    icons: ['Repo', 'Commit', 'Branch', 'PullRequest', 'Merge'],
+    icons: [
+      'Repo',
+      'Commit',
+      'Branch',
+      'PullRequest',
+      'Merge',
+    ]
   },
   {
     name: 'OS',
-    icons: ['Apple', 'Linux', 'Ubuntu', 'Windows', 'Chrome'],
+    icons: [
+      'Apple',
+      'Linux',
+      'Ubuntu',
+      'Windows',
+      'Chrome',
+    ]
   },
   {
     name: 'Logos',
@@ -100,7 +113,7 @@ export const iconList = [
       'Youtube',
       'VSCode',
       'Linkedin',
-    ],
+    ]
   },
   {
     name: 'Devices',
@@ -121,7 +134,7 @@ export const iconList = [
       'Structure',
       'Box',
       'Power',
-    ],
+    ]
   },
   {
     name: 'CRUD',
@@ -166,7 +179,7 @@ export const iconList = [
       'PointerDefault',
       'PointerHand',
       'Command',
-    ],
+    ]
   },
   {
     name: 'Communicate',
@@ -205,7 +218,7 @@ export const iconList = [
       'CloudHollow',
       'Cloud',
       'Sticker',
-    ],
+    ]
   },
   {
     name: 'Wayfinding',
@@ -246,7 +259,7 @@ export const iconList = [
       'Home',
       'Admin',
       'Direction',
-    ],
+    ]
   },
   {
     name: 'People',
@@ -261,6 +274,6 @@ export const iconList = [
       'FaceSad',
       'Accessibility',
       'AccessibilityAlt',
-    ],
+    ]
   },
 ];

--- a/src/icons/Drag.stories.tsx
+++ b/src/icons/Drag.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Drag } from './Drag';
+
+const meta: Meta<typeof Drag> = {
+  component: Drag,
+};
+
+export default meta;
+type Story = StoryObj<typeof Drag>;
+
+export const Default: Story = { args: { size: 100 } };

--- a/src/icons/Drag.tsx
+++ b/src/icons/Drag.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { IconProps } from '../types';
+import { IconWrapper } from '../IconWrapper';
+
+export const Drag = (allProps: IconProps) => {
+  const { svgProps: props, ...restProps } = allProps;
+  return (
+    <IconWrapper
+      icon={
+        <svg
+          width="100%"
+          height="100%"
+          viewBox="0 0 14 14"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          {...props}
+        >
+          <path
+            d="M13 4a.5.5 0 010 1H1a.5.5 0 010-1h12zM13.5 9.5A.5.5 0 0013 9H1a.5.5 0 000 1h12a.5.5 0 00.5-.5z"
+            fill="currentColor"
+          />
+        </svg>
+      }
+      {...restProps}
+    />
+  );
+};
+
+export default Drag;

--- a/src/index.ts
+++ b/src/index.ts
@@ -339,6 +339,13 @@ export const DocList = withSuspense(
   })
 );
 
+export const Drag = withSuspense(
+  lazy(async () => {
+    const m = await import('./groups/Documents');
+    return { default: m.Drag };
+  })
+);
+
 export const Markup = withSuspense(
   lazy(async () => {
     const m = await import('./groups/Editing');
@@ -1549,3 +1556,4 @@ export const AccessibilityAlt = withSuspense(
     return { default: m.AccessibilityAlt };
   })
 );
+


### PR DESCRIPTION
Ref https://github.com/storybookjs/storybook/pull/23635#issuecomment-1664341573

Looks like all dependencies are build only and should not bloat user installation with deprecated and vulnerable packages.