### PR TITLE
Fix peer dependencies to make sure it work for React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,8 +87,8 @@
     "vite": "4.2.1"
   },
   "peerDependencies": {
-    "react": ">=17",
-    "react-dom": ">=17"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "bugs": {
     "url": "https://github.com/storybook/icons/issues"


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/23721

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.4--canary.16.98b9dbb.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/icons@1.1.4--canary.16.98b9dbb.0
  # or 
  yarn add @storybook/icons@1.1.4--canary.16.98b9dbb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
