### PR TITLE
Fix repo, bugs and homepage `package.json` fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chromaui/icons.git"
+    "url": "git+https://github.com/storybookjs/icons.git"
   },
   "scripts": {
     "dev": "concurrently  -n \"Build,SB\" \"yarn build --watch\" \"yarn storybook\" ",
@@ -91,9 +91,9 @@
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "bugs": {
-    "url": "https://github.com/storybook/icons/issues"
+    "url": "https://github.com/storybookjs/icons/issues"
   },
-  "homepage": "https://github.com/storybook/icons#readme",
+  "homepage": "https://github.com/storybookjs/icons#readme",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
I noticed the links in the `package.json` point to `github.com/storybook` (the user) which should probably point to `github.com/storybookjs` the org.

This PR fixes that (and also changes `repository.url` while we're at it, even though redirect works fine)