### PR TITLE
Fix permissions auto

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Ensure that git uses your token with admin access to the repo
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare repository
+        # Fetch full git history and tags
         run: git fetch --unshallow --tags
 
       - name: Setup pnpm


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.7--canary.27.1274e42.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/icons@1.2.7--canary.27.1274e42.0
  # or 
  yarn add @storybook/icons@1.2.7--canary.27.1274e42.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
