### PR TITLE
Do not list react-dom as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,8 +77,7 @@
     "vite": "^7.2.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0",
   "publishConfig": {


### PR DESCRIPTION
None of the production code references `react-dom`, so listing it as a peer dependency is uneccessary.