### PR TITLE
Streamline release tooling: changesets + pkg.pr.new

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - next
 
 jobs:
   release-preview:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - next
 
 jobs:
   release:


### PR DESCRIPTION
## Summary
- remove `next` from the push branch filters in the release workflow
- remove `next` from the push branch filters in the pkg.pr.new preview workflow
- keep the repo on the existing changesets/pnpm/trusted-publishing-ready setup with main-only release pushes

## Validation
- `pnpm install --frozen-lockfile --prefer-offline --ignore-scripts`
- `pnpm lint`
- `pnpm exec prettier --check .github/workflows/release.yml .github/workflows/publish-preview.yml`
