### PR TITLE
Add changeset for new icons

### DIFF
--- a/.changeset/add-qr-sparkle-status-icons.md
+++ b/.changeset/add-qr-sparkle-status-icons.md
@@ -1,0 +1,5 @@
+---
+"@storybook/icons": minor
+---
+
+Add QRIcon, SparkleIcon, StatusAddIcon, and StatusRemoveIcon. Replace StatusNewIcon with SparkleIcon.


### PR DESCRIPTION
Adds the changeset file for the icons being introduced in #57 (QRIcon, SparkleIcon, StatusAddIcon, StatusRemoveIcon). Merging this alongside #57 will let the Changesets bot generate a Version Packages PR and publish to npm.

Minor bump since these are new additive exports.