### PR TITLE
Add changeset for react-dom peer dependency removal

### DIFF
--- a/.changeset/remove-react-dom-peer.md
+++ b/.changeset/remove-react-dom-peer.md
@@ -1,0 +1,5 @@
+---
+"@storybook/icons": patch
+---
+
+Remove `react-dom` from peer dependencies so non-DOM React projects do not receive unnecessary peer dependency warnings.


### PR DESCRIPTION
## Summary
- Adds a patch changeset for the existing `react-dom` peer dependency removal.
- Ensures the fix from `9cc242a` is included in the next `@storybook/icons` release.

## Testing
- `pnpm changeset status --since main`